### PR TITLE
生放送検索ページの文章が読みづらさの修正

### DIFF
--- a/src/style_for/live/search.scss
+++ b/src/style_for/live/search.scss
@@ -17,6 +17,14 @@
             .search-tab-anchor{
               background-color: $nico-black;
               color: $main-text-color;
+              .search-count.strong{
+                &::before{
+                  color: $nico-white;
+                }
+                &::after{
+                  color: $nico-white;
+                }
+              }
             }
             .search-tab-anchor::before{
               border-top-color: $nico-black;
@@ -47,7 +55,7 @@
             }
           }
         }
-        .search-result-summary{
+        .searchPage-SearchInputArea_ResultSummary{
           color: $sub-1-text-color;
         }
       }


### PR DESCRIPTION
# やったこと 

#81 を修正

合わせて検索結果の動画の件数の前後の括弧が黒くなっていたので同時に修正しました。

## Before
![スクリーンショット 2021-03-24 4 17 25](https://user-images.githubusercontent.com/19515213/112207523-93d3ab00-8c5a-11eb-884c-c005809311da.png)

## After
![スクリーンショット 2021-03-24 4 17 46](https://user-images.githubusercontent.com/19515213/112207632-b665c400-8c5a-11eb-9616-d329d7d2dc8b.png)

