### PR TITLE
メニューのスタイルを中央寄せに変更

### DIFF
--- a/src/style_for/browser_actions/index.scss
+++ b/src/style_for/browser_actions/index.scss
@@ -3,7 +3,7 @@
 body{
   background: $nico-black;
   width: 250px;
-  margin: 0;
+  margin: 0 auto;
   padding: 0;
 }
 


### PR DESCRIPTION
先程立てたisuueです #192
変更点はbrowser_actions/index.scssの6行目にautoを追加して中央寄せにしました
Chromeでは変更前と同じように動きます