### PR TITLE
新規インストール環境で総合TOPの設定変更ができないのを修正

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -20,6 +20,13 @@ chrome.runtime.onInstalled.addListener(function() {
           })
         }
       });
+      chrome.storage.local.get(["social_top"], function (items) {
+        if (items.social_top == undefined) {
+          chrome.storage.local.set({
+            "social_top": "true"
+          })
+        }
+      });
     };
   });
 });


### PR DESCRIPTION
niconico-darkmode を新規にインストールした環境で、総合 TOP の設定変更が出来ないのを修正しました。なお、既存の（新規インストールではない）環境では、問題が再現しない場合があります。

1b66726bdb5010f13a74c1e0aa01422d145b3dda このコミットですが、コメントの変更しかなく、修正できてなさそうに見えました。

maybe related: #194