### PR TITLE
#212 OSのダークモードが有効な時だけ適用

### DIFF
--- a/src/browser_actions/index.html
+++ b/src/browser_actions/index.html
@@ -29,6 +29,18 @@
           <span class="nicodark-span02"></span>
         </label>
       </label>
+
+      <div class="beta_setteings_area">
+        <label for="nicodark_set_os_settings_cb" class="nicodark-label01">
+          <span class="nicodark-span01">端末の設定に合わせる</span>
+          <label for="nicodark_set_os_settings_cb" id="nicodark-aria-set_os_settings" class="nicodark-label02">
+            <input type="checkbox" id="nicodark_set_os_settings_cb" class="nicodark-cb">
+            <span class="nicodark-span02"></span>
+          </label>
+        </label>
+        <p>この設定がオンの場合、他の設定は反映されません。</p>
+        <p>Firefoxにて一部のテーマを設定している場合、テーマ設定が優先されます。</p>
+      </div>
     </div>
     <p class="nicodark-setting-version-telop">
       <span id="show_version"></span>

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -27,6 +27,13 @@ chrome.runtime.onInstalled.addListener(function() {
           })
         }
       });
+      chrome.storage.local.get(["set_osdarkmode"], function (items) {
+        if (items.set_osdarkmode == undefined) {
+          chrome.storage.local.set({
+            "set_osdarkmode": "false"
+          })
+        }
+      });
     };
   });
 });
@@ -72,6 +79,21 @@ function change_settings(request_setting_param) {
       });
       send_change_settings("nicodark_top_to_false");
       break;
+
+    case "req_nicodark_osset_to_true":
+      chrome.storage.local.set({
+        "set_osdarkmode": "true"
+      });
+      send_change_settings("nicodark_osset_to_true");
+      break;
+
+    case "req_nicodark_osset_to_false":
+      chrome.storage.local.set({
+        "set_osdarkmode": "false"
+      });
+      send_change_settings("nicodark_osset_to_false");
+      break;
+  
 
     default:
       break;

--- a/src/js/browser_actions.js
+++ b/src/js/browser_actions.js
@@ -5,6 +5,7 @@
 //chrome.storageに突っ込むと文字列化されるので、面倒なので最初から文字列として定義しておく
 let is_darkmode = "true";
 let is_socialtop = "true";
+let isset_osdarkmode = "false";
 const MANIFEST_DATA = chrome.runtime.getManifest();
 const EX_VERSION = MANIFEST_DATA.version + "";
 
@@ -18,6 +19,10 @@ window.onload = function(){
   //総合TOP ボタン
   let nicodark_setting_cb_s_top = document.getElementById("nicodark_s_top-setting_cb");
   let nicodark_aria_s_top = document.getElementById("nicodark-aria-s_top");
+
+  //OS設定と合わせる ボタン
+  let nicodark_set_os_settings_cb = document.getElementById("nicodark_set_os_settings_cb");
+  let nicodark_aria_set_os_settings = document.getElementById("nicodark-aria-set_os_settings");
 
   //バージョン表示 
   document.getElementById("show_version").textContent = "nicodark v" + EX_VERSION;
@@ -49,6 +54,20 @@ window.onload = function(){
     }
 
     return is_socialtop;
+  });
+
+  chrome.storage.local.get(["set_osdarkmode"], function (items) {
+    isset_osdarkmode = items.set_osdarkmode;
+
+    if(items.set_osdarkmode === "false"){
+      nicodark_set_os_settings_cb.checked = false;
+      nicodark_aria_set_os_settings.setAttribute('aria-checked', 'false');
+    }else{
+      nicodark_set_os_settings_cb.checked = true;
+      nicodark_aria_set_os_settings.setAttribute('aria-checked', 'true');
+    }
+
+    return isset_osdarkmode;
   });
 
   //設定変更時処理　メッセージ送信
@@ -87,6 +106,25 @@ window.onload = function(){
       nicodark_setting_cb_s_top.checked = false;
       nicodark_aria_s_top.setAttribute('aria-checked', 'false');
       is_socialtop = "false";
+    }
+  }
+
+  nicodark_set_os_settings_cb.onclick = function(){
+    if(isset_osdarkmode === "false"){
+      chrome.runtime.sendMessage({request_change_settings: "req_nicodark_osset_to_true"}, function(response) {
+        console.log(response.farewell);
+      });
+      nicodark_set_os_settings_cb.checked = true;
+      nicodark_aria_set_os_settings.setAttribute('aria-checked', 'true');
+      isset_osdarkmode = "true";
+
+    }else if(isset_osdarkmode === "true"){
+      chrome.runtime.sendMessage({request_change_settings: "req_nicodark_osset_to_false"}, function(response) {
+        console.log(response.farewell);
+      });
+      nicodark_set_os_settings_cb.checked = false;
+      nicodark_aria_set_os_settings.setAttribute('aria-checked', 'false');
+      isset_osdarkmode = "false";
     }
   }
 }

--- a/src/style_for/browser_actions/index.scss
+++ b/src/style_for/browser_actions/index.scss
@@ -33,6 +33,7 @@ body{
   }
   .nicodark-setting-menu{
     padding: 0px 16px 8px 16px;
+    position: relative;
 
     .nicodark-label01{
       display: flex;
@@ -84,6 +85,36 @@ body{
       }
     }
     
+
+    .beta_setteings_area{
+      border: 1px solid $nico-premium;
+      border-radius: 5px;
+      margin: 5px 0;
+      padding: 0 0 5px 0;
+      overflow: hidden;
+
+      p{
+        color: $main-text-color;
+        font-size: 10px;
+        margin: .1rem .5rem;
+        line-height: 1.2;
+
+        &+p{
+          margin: .25rem .5rem;
+        }
+      }
+
+      &::before{
+        content: "拡張設定 (BETA)";
+        top: 0;
+        padding: .1rem .5rem;
+        text-align: center;
+        font-size: 12px;
+        background-color: $nico-premium;
+        color: $main-text-color;
+        border-radius: 0 5px 5px 0;
+      }
+    }
   }
 
   .onelineinfo{


### PR DESCRIPTION
## 変更点
- 設定パネルのボタン追加
- 設定情報の追加
- 設定処理の追加

### 詳細
- `window.matchMedia('(prefers-color-scheme: dark)')` でOSの設定を取得
- OS側の設定が変更された時 `addEventLisner` で変更を取得し、自動変更

### 備考
- Firefoxにて「Light」「Dark」のテーマが設定されている場合、OSの設定よりもテーマ設定が優先される。
- OS設定に合わせるモードがオンの時は、他設定を変更しても反映されない（設定保存処理自体は動くので、OS同期を解除すると最新の設定から復旧する）