### PR TITLE
お知らせがない場合の文章にスタイルを適用

### DIFF
--- a/src/style_for/inform/_oshirase_list.scss
+++ b/src/style_for/inform/_oshirase_list.scss
@@ -60,6 +60,11 @@
 
           
         }
+        .kYHXcA{
+          p.text{
+            color: $main-text-color;
+          }
+        }
       }
     }
 


### PR DESCRIPTION
#228 を修正 

何もお知らせがないときは "kYHXcA" クラスのついた要素ができるのでその中のテキストに$main-text-colorを適用