### PR TITLE
#250 マイページの動画メニューがずれて見えなくなる問題を修正

### DIFF
--- a/src/style_for/video/mypage/_mypage-card.scss
+++ b/src/style_for/video/mypage/_mypage-card.scss
@@ -233,7 +233,9 @@
       }
     }
     .NC-MediaObject-action{
-      filter: $invert;
+      .NC-ThreePointMenu-menu{
+        filter: $invert;
+      }
     }
   }
   /* 20210601 fix end */


### PR DESCRIPTION
filterがpositionの基準点をずらすようなのでフィルターの位置を修正
詳細は#250